### PR TITLE
Added Extractor Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ elements = {
     "Comments": "Number of comments",
 }
 
-scrapper = Parsera()
-result = scrapper.run(url=url, elements=elements)
+scraper = Parsera()
+result = scraper.run(url=url, elements=elements)
 ```
 
 `result` variable will contain a json with a list of records:

--- a/README.md
+++ b/README.md
@@ -93,3 +93,37 @@ scrapper = Parsera(model=llm)
 result = scrapper.run(url=url, elements=elements)
 ```
 
+## Using different extractor types
+By default a tabular extractor is used, but you can also use the list or item extractors:
+```python
+from parsera import Parsera
+
+scraper = Parsera(extractor=Parsera.ExtractorType.LIST)
+# or
+scraper = Parsera(extractor=Parsera.ExtractorType.ITEM)
+```
+
+The tabular extractor is used to find rows of tabular data and has output of the form:
+```json
+[
+    {"name": "name1", "price": "100"},
+    {"name": "name2", "price": "150"},
+    {"name": "name3", "price": "300"},
+]
+```
+
+The list extractor is used to find lists of different values and has output of the form:
+```json
+{
+    "name": ["name1", "name2", "name3"],
+    "price": ["100", "150", "300"]
+}
+```
+
+The item extractor is used to get singular items from a page like a title or price and has output of the form:
+```json
+{
+    "name": "name1",
+    "price": "100"
+}
+```

--- a/parsera/engine/simple_extractor.py
+++ b/parsera/engine/simple_extractor.py
@@ -3,42 +3,8 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import JsonOutputParser
 from markdownify import markdownify
+from typing import Optional
 
-LIST_EXTRACTOR_SYSTEM_PROMPT = """
-Your goal is to find the elements from the webpage content and return them in json format.
-For example if user asks:
-Return the following elements from the page content:
-```
-{
-    "name": "name of the listing",
-    "price": "price of the listing"
-}
-```
-Make sure to return json with the list of corresponding values.
-Output json:
-```json
-{
-    "name": ["name1", "name2", "name3"],
-    "price": ["100", "150", "300"]
-}
-```
-
-If users asks for a single field:
-Return the following elements from the page content:
-```
-{
-    "link": "link to the listing",
-}
-```
-Make sure to return json with only this field
-Output json:
-```json
-{
-    "link": ["https://example.com/link1", "https://example.com/link2", "https://example.com/link3"]
-}
-```
-
-"""
 
 SIMPLE_EXTRACTOR_PROMPT_TEMPLATE = """
 Having following page content:
@@ -56,8 +22,8 @@ Output json:
 
 
 class Extractor:
-    system_prompt = LIST_EXTRACTOR_SYSTEM_PROMPT
-    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
+    system_prompt: Optional[str] = None
+    prompt_template: Optional[str] = None
     def __init__(self, elements: dict, model: BaseChatModel, content: str):
         self.elements = elements
         self.model = model
@@ -65,8 +31,12 @@ class Extractor:
 
 
     async def run(self) -> dict:
-        markdown = markdownify(self.content)
+        if self.system_prompt is None:
+            raise ValueError("system_prompt is not defined for this extractor")
+        if self.prompt_template is None:
+            raise ValueError("prompt_template is not defined for this extractor")
 
+        markdown = markdownify(self.content)
         elements = json.dumps(self.elements)
         human_msg = self.prompt_template.format(markdown=markdown, elements=elements)
         messages = [
@@ -76,6 +46,7 @@ class Extractor:
         output = await self.model.ainvoke(messages)
         parser = JsonOutputParser()
         output_dict = parser.parse(output.content)
+
         return output_dict
 
 
@@ -120,10 +91,47 @@ Output json:
 
 class TabularExtractor(Extractor):
     system_prompt = TABULAR_EXTRACTOR_SYSTEM_PROMPT
+    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
 
+LIST_EXTRACTOR_SYSTEM_PROMPT = """
+Your goal is to find the elements from the webpage content and return them in json format.
+For example if user asks:
+Return the following elements from the page content:
+```
+{
+    "name": "name of the listing",
+    "price": "price of the listing"
+}
+```
+Make sure to return json with the list of corresponding values.
+Output json:
+```json
+{
+    "name": ["name1", "name2", "name3"],
+    "price": ["100", "150", "300"]
+}
+```
+
+If users asks for a single field:
+Return the following elements from the page content:
+```
+{
+    "link": "link to the listing",
+}
+```
+Make sure to return json with only this field
+Output json:
+```json
+{
+    "link": ["https://example.com/link1", "https://example.com/link2", "https://example.com/link3"]
+}
+```
+
+"""
 
 class ListExtractor(Extractor):
     system_prompt = LIST_EXTRACTOR_SYSTEM_PROMPT
+    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
 
 ITEM_EXTRACTOR_SYSTEM_PROMPT = """
 Your goal is to find the elements from the webpage content and return them in json format.
@@ -162,3 +170,4 @@ Output json:
 """
 class ItemExtractor(Extractor):
     system_prompt = ITEM_EXTRACTOR_SYSTEM_PROMPT
+    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE

--- a/parsera/engine/simple_extractor.py
+++ b/parsera/engine/simple_extractor.py
@@ -122,7 +122,7 @@ Output json:
 ```json
 {
     "name": ["name1", "name2", "name3"],
-    "price": "100", "150", "300"]
+    "price": ["100", "150", "300"]
 }
 ```
 

--- a/parsera/engine/simple_extractor.py
+++ b/parsera/engine/simple_extractor.py
@@ -4,7 +4,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import JsonOutputParser
 from markdownify import markdownify
 
-SIMPLE_EXTRACTOR_SYSTEM_PROMPT = """
+LIST_EXTRACTOR_SYSTEM_PROMPT = """
 Your goal is to find the elements from the webpage content and return them in json format.
 For example if user asks:
 Return the following elements from the page content:
@@ -18,10 +18,26 @@ Make sure to return json with the list of corresponding values.
 Output json:
 ```json
 {
-    "names": ["name1", "name2", "name3"],
-    "price": ["100", "150", "300"],
+    "name": ["name1", "name2", "name3"],
+    "price": ["100", "150", "300"]
 }
 ```
+
+If users asks for a single field:
+Return the following elements from the page content:
+```
+{
+    "link": "link to the listing",
+}
+```
+Make sure to return json with only this field
+Output json:
+```json
+{
+    "link": ["https://example.com/link1", "https://example.com/link2", "https://example.com/link3"]
+}
+```
+
 """
 
 SIMPLE_EXTRACTOR_PROMPT_TEMPLATE = """
@@ -39,14 +55,14 @@ Output json:
 """
 
 
-class JsonExtractor:
-    system_prompt = SIMPLE_EXTRACTOR_SYSTEM_PROMPT
+class Extractor:
+    system_prompt = LIST_EXTRACTOR_SYSTEM_PROMPT
     prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
-
     def __init__(self, elements: dict, model: BaseChatModel, content: str):
         self.elements = elements
         self.model = model
         self.content = content
+
 
     async def run(self) -> dict:
         markdown = markdownify(self.content)
@@ -102,47 +118,11 @@ Output json:
 
 """
 
-
-class TabularExtractor(JsonExtractor):
+class TabularExtractor(Extractor):
     system_prompt = TABULAR_EXTRACTOR_SYSTEM_PROMPT
 
 
-LIST_EXTRACTOR_SYSTEM_PROMPT = """
-Your goal is to find the elements from the webpage content and return them in json format.
-For example if user asks:
-Return the following elements from the page content:
-```
-{
-    "name": "name of the listing",
-    "price": "price of the listing"
-}
-```
-Make sure to return json with the list of corresponding values.
-Output json:
-```json
-{
-    "name": ["name1", "name2", "name3"],
-    "price": ["100", "150", "300"]
-}
-```
-
-If users asks for a single field:
-Return the following elements from the page content:
-```
-{
-    "link": "link to the listing",
-}
-```
-Make sure to return json with only this field
-Output json:
-```json
-{
-    "link": ["https://example.com/link1", "https://example.com/link2", "https://example.com/link3"]
-}
-```
-
-"""
-class ListExtractor(JsonExtractor):
+class ListExtractor(Extractor):
     system_prompt = LIST_EXTRACTOR_SYSTEM_PROMPT
 
 ITEM_EXTRACTOR_SYSTEM_PROMPT = """
@@ -180,5 +160,5 @@ Output json:
 ```
 
 """
-class ItemExtractor(JsonExtractor):
+class ItemExtractor(Extractor):
     system_prompt = ITEM_EXTRACTOR_SYSTEM_PROMPT

--- a/parsera/engine/simple_extractor.py
+++ b/parsera/engine/simple_extractor.py
@@ -1,5 +1,4 @@
 import json
-
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.output_parsers import JsonOutputParser
@@ -106,3 +105,80 @@ Output json:
 
 class TabularExtractor(JsonExtractor):
     system_prompt = TABULAR_EXTRACTOR_SYSTEM_PROMPT
+
+
+LIST_EXTRACTOR_SYSTEM_PROMPT = """
+Your goal is to find the elements from the webpage content and return them in json format.
+For example if user asks:
+Return the following elements from the page content:
+```
+{
+    "name": "name of the listing",
+    "price": "price of the listing"
+}
+```
+Make sure to return json with the list of corresponding values.
+Output json:
+```json
+{
+    "name": ["name1", "name2", "name3"],
+    "price": "100", "150", "300"]
+}
+```
+
+If users asks for a single field:
+Return the following elements from the page content:
+```
+{
+    "link": "link to the listing",
+}
+```
+Make sure to return json with only this field
+Output json:
+```json
+{
+    "link": ["https://example.com/link1", "https://example.com/link2", "https://example.com/link3"]
+}
+```
+
+"""
+class ListExtractor(JsonExtractor):
+    system_prompt = LIST_EXTRACTOR_SYSTEM_PROMPT
+
+ITEM_EXTRACTOR_SYSTEM_PROMPT = """
+Your goal is to find the elements from the webpage content and return them in json format.
+For example if user asks:
+Return the following elements from the page content:
+```
+{
+    "name": "name of the listing",
+    "price": "price of the listing"
+}
+```
+Make sure to return a json with corresponding values.
+Output json:
+```json
+{
+    "name": "name1",
+    "price": "100"
+}
+```
+
+If users asks for a single field:
+Return the following elements from the page content:
+```
+{
+    "link": "link to the listing",
+}
+```
+Make sure to return json with only this field
+Output json:
+```json
+{
+    "link": "https://example.com/link1"]
+}
+```
+
+"""
+class ItemExtractor(JsonExtractor):
+    system_prompt = ITEM_EXTRACTOR_SYSTEM_PROMPT

--- a/parsera/main.py
+++ b/parsera/main.py
@@ -1,18 +1,23 @@
 import asyncio
-
 from langchain_core.language_models import BaseChatModel
-
+import enum
 from parsera.engine.model import GPT4oMiniModel
-from parsera.engine.simple_extractor import TabularExtractor
+from parsera.engine.simple_extractor import TabularExtractor, ListExtractor, ItemExtractor
 from parsera.page import fetch_page_content
 
 
 class Parsera:
-    def __init__(self, model: BaseChatModel | None = None):
+    class ExtractorType(enum.Enum):
+        LIST = ListExtractor
+        TABULAR = TabularExtractor
+        ITEM = ItemExtractor
+
+    def __init__(self, model: BaseChatModel | None = None, extractor: ExtractorType = ExtractorType.TABULAR):
         if model is None:
             self.model = GPT4oMiniModel()
         else:
             self.model = model
+        self.extractor = extractor
 
     async def _run(
         self, url: str, elements: dict, proxy_settings: dict | None = None
@@ -21,10 +26,10 @@ class Parsera:
             content = await fetch_page_content(url=url, proxy_settings=proxy_settings)
         else:
             content = await fetch_page_content(url=url)
-        extractor = TabularExtractor(
+        extractor_instance = self.extractor.value(
             elements=elements, model=self.model, content=content
         )
-        result = await extractor.run()
+        result = await extractor_instance.run()
         return result
 
     def run(self, url: str, elements: dict, proxy_settings: dict | None = None) -> dict:


### PR DESCRIPTION
Here's a summary of my changes:
- Added List Extractor to get items that come in lists
- Added Item Extractor type to get items that are singular i.e. page title or description
- Add the ExtractorType enum with each of the different extractor types for type hinting
- Changed Parsera._run to use the extractor type selected
- Added examples of how the different Extractor Types can be used to the README

I think these changes make this package more useful. Especially for data types that aren't tabular such as the title of a webpage where you only want to get a single value. Feel free to change things in my PR as needed or let me know if you'd like me to work on it some more, thanks.

Addresses #2 