### PR TITLE
Support HuggingFace Transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,32 +94,35 @@ result = scrapper.run(url=url, elements=elements)
 ```
 
 You can also use `Parsera` with HuggingFace `Transformers` .
+Currently, we only support models that include a `system` token
 
-> You should install `Transformers` with either `pytorch` or `TensorFlow 2.0`
+> You should install `Transformers` with either `pytorch` (recommended) or `TensorFlow 2.0`
 
 [Transformers Installation Guide](https://huggingface.co/docs/transformers/en/installation)
 
 example:
 ```python
-from  transformers  import  pipeline, AutoTokenizer, AutoModelForCausalLM
-from  langchain.base_language  import  BaseLanguageModel
-from  parsera  import ParseraHuggingFace
+from transformers import pipeline, AutoTokenizer, AutoModelForCausalLM
+from parsera.engine.model import HuggingFaceModel
+from parsera import Parsera
 
 # Define the URL and elements to scrape
-url  =  "https://news.ycombinator.com/"
-elements  = {
+url = "https://news.ycombinator.com/"
+elements = {
 "Title": "News title",
 "Points": "Number of points",
 "Comments": "Number of comments",
 }
 
 # Initialize model with transformers pipeline
-tokenizer  = AutoTokenizer.from_pretrained("google/gemma-2-2b-it")
-model  = AutoModelForCausalLM.from_pretrained("google/gemma-2-2b-it")
-pipe  =  pipeline("text-generation", model=model, tokenizer=tokenizer, max_new_tokens=5000, device='mps')
+tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3-mini-128k-instruct", trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained("microsoft/Phi-3-mini-128k-instruct", trust_remote_code=True)
+pipe = pipeline("text-generation", model=model, tokenizer=tokenizer, max_new_tokens=5000)
 
+# Initialize HuggingFaceModel
+llm = HuggingFaceModel(pipeline=pipe)
 
 # Scrapper with HuggingFace model
-scrapper  = ParseraHuggingFace(model=pipe)
-result  =  scrapper.run(url=url, elements=elements)
+scrapper = Parsera(model=llm)
+result = scrapper.run(url=url, elements=elements)
 ```

--- a/README.md
+++ b/README.md
@@ -93,3 +93,33 @@ scrapper = Parsera(model=llm)
 result = scrapper.run(url=url, elements=elements)
 ```
 
+You can also use `Parsera` with HuggingFace `Transformers` .
+
+> You should install `Transformers` with either `pytorch` or `TensorFlow 2.0`
+
+[Transformers Installation Guide](https://huggingface.co/docs/transformers/en/installation)
+
+example:
+```python
+from  transformers  import  pipeline, AutoTokenizer, AutoModelForCausalLM
+from  langchain.base_language  import  BaseLanguageModel
+from  parsera  import ParseraHuggingFace
+
+# Define the URL and elements to scrape
+url  =  "https://news.ycombinator.com/"
+elements  = {
+"Title": "News title",
+"Points": "Number of points",
+"Comments": "Number of comments",
+}
+
+# Initialize model with transformers pipeline
+tokenizer  = AutoTokenizer.from_pretrained("google/gemma-2-2b-it")
+model  = AutoModelForCausalLM.from_pretrained("google/gemma-2-2b-it")
+pipe  =  pipeline("text-generation", model=model, tokenizer=tokenizer, max_new_tokens=5000, device='mps')
+
+
+# Scrapper with HuggingFace model
+scrapper  = ParseraHuggingFace(model=pipe)
+result  =  scrapper.run(url=url, elements=elements)
+```

--- a/parsera/__init__.py
+++ b/parsera/__init__.py
@@ -1,3 +1,3 @@
-from parsera.main import Parsera
+from parsera.main import Parsera, ParseraHuggingFace
 
-__all__ = ["Parsera"]
+__all__ = ["Parsera", "ParseraHuggingFace"]

--- a/parsera/__init__.py
+++ b/parsera/__init__.py
@@ -1,3 +1,9 @@
-from parsera.main import Parsera, ParseraHuggingFace
+from parsera.main import Parsera
 
 __all__ = ["Parsera", "ParseraHuggingFace"]
+
+def __getattr__(name):
+    if name == "ParseraHuggingFace":
+        from parsera.main import ParseraHuggingFace
+        return ParseraHuggingFace
+    raise AttributeError(f"module 'parsera' has no attribute '{name}'")

--- a/parsera/__init__.py
+++ b/parsera/__init__.py
@@ -1,9 +1,3 @@
 from parsera.main import Parsera
 
-__all__ = ["Parsera", "ParseraHuggingFace"]
-
-def __getattr__(name):
-    if name == "ParseraHuggingFace":
-        from parsera.main import ParseraHuggingFace
-        return ParseraHuggingFace
-    raise AttributeError(f"module 'parsera' has no attribute '{name}'")
+__all__ = ["Parsera"]

--- a/parsera/engine/model.py
+++ b/parsera/engine/model.py
@@ -4,6 +4,15 @@ from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
 from parsera.utils import singleton
 
+from langchain.chat_models.base import BaseChatModel
+from typing import List, Optional, Any
+from langchain_core.outputs.chat_generation import ChatGeneration
+from langchain_core.callbacks.manager import CallbackManagerForLLMRun, AsyncCallbackManagerForLLMRun
+from langchain_core.outputs.chat_result import ChatResult
+from langchain.chat_models.base import BaseMessage
+from langchain_core.messages.ai import AIMessage
+from functools import partial
+import asyncio
 
 @singleton
 class AzureModel(AzureChatOpenAI):
@@ -31,3 +40,64 @@ class GPT4oMiniModel(ChatOpenAI):
             *args,
             **kwargs,
         )
+
+@singleton
+class HuggingFaceModel(BaseChatModel):
+    """
+    Model for using HuggingFace pipeline.
+
+    Imports embeded in the class to avoid all users 
+    from having to install necessary dependencies 
+    for this model.
+    """
+    from transformers import pipeline
+    from transformers import Pipeline
+
+    pipeline: Pipeline
+
+    def _generate(
+    self,
+    messages: List[BaseMessage],
+    stop: Optional[List[str]] = None,
+    run_manager: Optional[CallbackManagerForLLMRun] = None,
+    **kwargs: Any,
+    ) -> ChatResult:
+        # Implement the logic for generating the response using the HuggingFace model
+        output_str = self._call(messages, stop=stop, run_manager=run_manager, **kwargs)
+        message = AIMessage(content=output_str)
+        generation = ChatGeneration(message=message)
+        return ChatResult(generations=[generation])
+    
+    def _call(
+    self,
+    messages: List[BaseMessage],
+    stop: Optional[List[str]] = None,
+    run_manager: Optional[CallbackManagerForLLMRun] = None,
+    **kwargs: Any,
+    ) -> str:
+        pipe = self.pipeline
+        prompt = " ".join([message.content for message in messages])
+        # Define the messages
+        messages = [
+            {"role": "user", "content": prompt}
+        ]
+        response = pipe(messages)
+        generated_text = response[0]['generated_text'][-1]['content']
+        return generated_text
+    
+    async def _agenerate(
+    self,
+    messages: List[BaseMessage],
+    stop: Optional[List[str]] = None,
+    run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+    **kwargs: Any,
+    ) -> ChatResult:
+        func = partial(
+            self._generate, messages, stop=stop, run_manager=run_manager, **kwargs
+        )
+        return await asyncio.get_event_loop().run_in_executor(None, func)
+    
+    @property
+    def _llm_type(self) -> str:
+        """Get the type of language model used by this chat model."""
+        return "custom"

--- a/parsera/engine/model.py
+++ b/parsera/engine/model.py
@@ -50,10 +50,7 @@ class HuggingFaceModel(BaseChatModel):
     from having to install necessary dependencies 
     for this model.
     """
-    from transformers import pipeline
-    from transformers import Pipeline
-
-    pipeline: Pipeline
+    model: Any
 
     def _generate(
     self,
@@ -75,7 +72,7 @@ class HuggingFaceModel(BaseChatModel):
     run_manager: Optional[CallbackManagerForLLMRun] = None,
     **kwargs: Any,
     ) -> str:
-        pipe = self.pipeline
+        pipe = self.model
         prompt = " ".join([message.content for message in messages])
         # Define the messages
         messages = [

--- a/parsera/engine/model.py
+++ b/parsera/engine/model.py
@@ -50,7 +50,9 @@ class HuggingFaceModel(BaseChatModel):
     from having to install necessary dependencies 
     for this model.
     """
-    model: Any
+
+    pipeline: Any
+    """HuggingFace Transformers Pipeline"""
 
     def _generate(
     self,
@@ -72,14 +74,21 @@ class HuggingFaceModel(BaseChatModel):
     run_manager: Optional[CallbackManagerForLLMRun] = None,
     **kwargs: Any,
     ) -> str:
-        pipe = self.model
-        prompt = " ".join([message.content for message in messages])
-        # Define the messages
+        from transformers import Pipeline
+
+        if not isinstance(self.pipeline, Pipeline):
+            raise ValueError("pipeline must be a HuggingFace Pipeline")
+        
+        pipe = self.pipeline
+
         messages = [
-            {"role": "user", "content": prompt}
+            {"role": "system", "content": messages[0].content},
+            {"role": "user", "content": messages[1].content}
         ]
+
         response = pipe(messages)
         generated_text = response[0]['generated_text'][-1]['content']
+        
         return generated_text
     
     async def _agenerate(

--- a/parsera/main.py
+++ b/parsera/main.py
@@ -2,10 +2,10 @@ import asyncio
 
 from langchain_core.language_models import BaseChatModel
 
-from parsera.engine.model import GPT4oMiniModel
+from parsera.engine.model import GPT4oMiniModel, HuggingFaceModel
 from parsera.engine.simple_extractor import TabularExtractor
 from parsera.page import fetch_page_content
-
+from transformers import Pipeline
 
 class Parsera:
     def __init__(self, model: BaseChatModel | None = None):
@@ -13,6 +13,38 @@ class Parsera:
             self.model = GPT4oMiniModel()
         else:
             self.model = model
+
+    async def _run(
+        self, url: str, elements: dict, proxy_settings: dict | None = None
+    ) -> dict:
+        if proxy_settings:
+            content = await fetch_page_content(url=url, proxy_settings=proxy_settings)
+        else:
+            content = await fetch_page_content(url=url)
+        extractor = TabularExtractor(
+            elements=elements, model=self.model, content=content
+        )
+        result = await extractor.run()
+        return result
+
+    def run(self, url: str, elements: dict, proxy_settings: dict | None = None) -> dict:
+        return asyncio.run(
+            self._run(url=url, elements=elements, proxy_settings=proxy_settings)
+        )
+
+    async def arun(
+        self, url: str, elements: dict, proxy_settings: dict | None = None
+    ) -> dict:
+        return await self._run(
+            url=url, elements=elements, proxy_settings=proxy_settings
+        )
+
+class ParseraHuggingFace:
+    def __init__(self, model: Pipeline | None = None):
+        if model:
+            self.model = HuggingFaceModel(pipeline=model)
+        else:
+            raise ValueError("Model is required")
 
     async def _run(
         self, url: str, elements: dict, proxy_settings: dict | None = None

--- a/parsera/main.py
+++ b/parsera/main.py
@@ -38,39 +38,3 @@ class Parsera:
         return await self._run(
             url=url, elements=elements, proxy_settings=proxy_settings
         )
-
-class ParseraHuggingFace:
-    def __init__(self, model: Any | None = None):
-        from transformers import Pipeline
-        from parsera.engine.model import HuggingFaceModel
-
-        if not isinstance(model, Pipeline):
-            raise ValueError("model must be an instance of transformers.Pipeline")
-
-        if model:
-            self.model = HuggingFaceModel(model=model)
-
-    async def _run(
-        self, url: str, elements: dict, proxy_settings: dict | None = None
-    ) -> dict:
-        if proxy_settings:
-            content = await fetch_page_content(url=url, proxy_settings=proxy_settings)
-        else:
-            content = await fetch_page_content(url=url)
-        extractor = TabularExtractor(
-            elements=elements, model=self.model, content=content
-        )
-        result = await extractor.run()
-        return result
-
-    def run(self, url: str, elements: dict, proxy_settings: dict | None = None) -> dict:
-        return asyncio.run(
-            self._run(url=url, elements=elements, proxy_settings=proxy_settings)
-        )
-
-    async def arun(
-        self, url: str, elements: dict, proxy_settings: dict | None = None
-    ) -> dict:
-        return await self._run(
-            url=url, elements=elements, proxy_settings=proxy_settings
-        )

--- a/parsera/main.py
+++ b/parsera/main.py
@@ -5,7 +5,6 @@ from langchain_core.language_models import BaseChatModel
 from parsera.engine.model import GPT4oMiniModel
 from parsera.engine.simple_extractor import TabularExtractor
 from parsera.page import fetch_page_content
-from typing import Any
 
 class Parsera:
     def __init__(self, model: BaseChatModel | None = None):

--- a/parsera/main.py
+++ b/parsera/main.py
@@ -2,10 +2,10 @@ import asyncio
 
 from langchain_core.language_models import BaseChatModel
 
-from parsera.engine.model import GPT4oMiniModel, HuggingFaceModel
+from parsera.engine.model import GPT4oMiniModel
 from parsera.engine.simple_extractor import TabularExtractor
 from parsera.page import fetch_page_content
-from transformers import Pipeline
+from typing import Any
 
 class Parsera:
     def __init__(self, model: BaseChatModel | None = None):
@@ -40,11 +40,15 @@ class Parsera:
         )
 
 class ParseraHuggingFace:
-    def __init__(self, model: Pipeline | None = None):
+    def __init__(self, model: Any | None = None):
+        from transformers import Pipeline
+        from parsera.engine.model import HuggingFaceModel
+
+        if not isinstance(model, Pipeline):
+            raise ValueError("model must be an instance of transformers.Pipeline")
+
         if model:
-            self.model = HuggingFaceModel(pipeline=model)
-        else:
-            raise ValueError("Model is required")
+            self.model = HuggingFaceModel(model=model)
 
     async def _run(
         self, url: str, elements: dict, proxy_settings: dict | None = None


### PR DESCRIPTION
This PR introduces support for HuggingFace `Transformers` in `Parsera` by adding a new `HuggingFaceModel`. Users only need to install `Transformers` when they choose to use it, as the module is not loaded until `Parsera` is initialized with `HuggingFaceModel` as the model.

~~This PR introduces support for HuggingFace Transformers by adding a new class, `ParseraHuggingFace`. The class is designed for lazy loading, ensuring that users only install the `transformers` library if they choose to use it.~~

List of changes:

- **Added:** custom `HuggingFaceModel` in `model.py`
- **Added:** support for `HuggingFaceModel` in `Parsera`
- **Updated:** `README` with examples for using `HuggingFaceModel` with `Parsera`

~~- **Added:** `ParseraHuggingFace` class for HuggingFace integration.~~