### PR TITLE
WIP: Chunks extractor

### DIFF
--- a/parsera/engine/chunks_extractor.py
+++ b/parsera/engine/chunks_extractor.py
@@ -249,6 +249,24 @@ class ChunksTabularExtractor(Extractor):
         output_dict = parser.parse(output.content)
         return output_dict
 
+    async def merge_all_data(self, all_data):
+        elements = json.dumps(self.elements)
+        json_list = ""
+        for data in all_data:
+            json_list += "``` \n" + json.dumps(data) + "\n ```\n"
+
+        human_msg = self.prompt_merge_template.format(
+            elements=elements, jsons_list=json_list
+        )
+        messages = [
+            SystemMessage(self.system_merge_prompt),
+            HumanMessage(human_msg),
+        ]
+        output = await self.model.ainvoke(messages)
+        parser = JsonOutputParser()
+        output_dict = parser.parse(output.content)
+        return output_dict
+
     async def run(
         self,
     ) -> dict:

--- a/parsera/engine/chunks_extractor.py
+++ b/parsera/engine/chunks_extractor.py
@@ -1,0 +1,281 @@
+import json
+import math
+from typing import Callable
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from markdownify import markdownify
+
+from parsera.engine.simple_extractor import Extractor
+
+TABULAR_EXTRACTOR_SYSTEM_PROMPT = """
+Your goal is to find the elements from the webpage content and return them in json format.
+For example if user asks:
+Return the following elements from the page content:
+```
+{
+    "name": "name of the listing",
+    "price": "price of the listing"
+}
+```
+Make sure to return json with the list of corresponding values.
+Output json:
+```json
+[
+    {"name": "name1", "price": "100"},
+    {"name": "name2", "price": "150"},
+    {"name": "name3", "price": "300"},
+]
+```
+
+If users asks for a single field:
+Return the following elements from the page content:
+```
+{
+    "link": "link to the listing",
+}
+```
+Make sure to return json with only this field
+Output json:
+```json
+[
+    {"link": "https://example.com/link1"},
+    {"link": "https://example.com/link2"},
+    {"link": "https://example.com/link3"},
+]
+```
+
+If value for the field is not found use `null` in the json:
+```json
+[
+    {"name": "name1", "price": "100"},
+    {"name": "name2", "price": null},
+    {"name": "name3", "price": "300"},
+]
+```
+
+If no data is found return empty json:
+```json
+[]
+```
+
+"""
+
+
+SYSTEM_MERGE_PROMPT_TEMPLATE = """
+Your goal is to merge data extracted from different parts of the page into one json.
+Keep the original structure, but make sure to correctly merge data to not have duplicates.
+
+In case of conflicting values, take the data that is further from the boarder between the files.
+For example if merging the following jsons:
+```
+[
+    {"name": "zero element", "price": "123"},
+    {"name": "first element", "price": "100"},
+    {"name": "second element", "price": "200"},
+    {"name": "third element", "price": "999"},
+]
+```
+
+and 
+
+```
+[
+    {"name": "second element", "price": "123"},
+    {"name": "third element", "price": "400"},
+]
+```
+
+In the case above the "second element"'s price should be taken from the first json, cause it's further from the boarder
+between the files, while "third element"'s price should be taken from the second json. The final output should be:
+
+```
+[
+    {"name": "zero element", "price": "123"},
+    {"name": "first element", "price": "100"},
+    {"name": "second element", "price": "200"},
+    {"name": "third element", "price": "400"},
+]
+```
+
+"""
+
+EXTRACTOR_MERGE_PROMPT_TEMPLATE = """
+Elements requested by user:
+```
+{elements}
+```
+
+All jsons from different parts of the page:
+{jsons_list}
+
+Merged json:
+"""
+
+APPEND_TABULAR_EXTRACTOR_SYSTEM_PROMPT = """
+Your goal is to continue the sequence extracted from the previous chunk of the page by adding elements from the new page
+chunk. Note, that chunks are overlapping, so the data extracted from the previous chunk can appear in the content again,
+in this case always prefer the data from the truncated page chunk. 
+Output json should contain all records you observe on the page.
+
+## Example: continue truncated json
+Fix and continue this sequence:
+```json
+[
+    {"name": "zero product", "price": "25"},
+    {"name": "first product", "price": "100"},
+    {"name": "second", "price": null},
+]
+```
+
+Return the following elements from the truncated page chunk:
+```
+{
+    "name": "name of the listing",
+    "price": "price of the listing"
+}
+```
+
+Make sure to fill mussing and truncated values in the previous sequence, while using `null` in the records where data
+was not found. Like in example below, where price for the "fourth product" was not found.
+Output json:
+```json
+[
+    {"name": "zero product", "price": "25"},
+    {"name": "first product", "price": "100"},
+    {"name": "second product", "price": "100"},
+    {"name": "third product", "price": "150"},
+    {"name": "fourth product", "price": null},
+]
+```
+
+## Example: user asks for single field
+
+User requesting the following elements from the truncated page chunk:
+```
+{
+    "link": "link to the listing",
+}
+```
+Make sure to return json with only this field
+Output json:
+```json
+[
+    {"link": "https://example.com/link1"},
+    {"link": "https://example.com/link2"},
+    {"link": "https://example.com/link3"},
+]
+```
+
+## Note
+
+If no data is found return empty json:
+```json
+[]
+```
+
+"""
+
+APPEND_EXTRACTOR_PROMPT_TEMPLATE = """
+Fix and continue this sequence:
+```
+{previous_data}
+```
+
+The current truncated page chunk:
+---
+{markdown}
+---
+
+You are looking for the following elements from the truncated page chunk:
+```
+{elements}
+```
+
+Output json with all elements from the previous sequence where new data was found:
+"""
+
+
+class ChunksTabularExtractor(Extractor):
+    system_prompt = TABULAR_EXTRACTOR_SYSTEM_PROMPT
+    system_merge_prompt = SYSTEM_MERGE_PROMPT_TEMPLATE
+    prompt_merge_template = EXTRACTOR_MERGE_PROMPT_TEMPLATE
+    append_system_prompt = APPEND_TABULAR_EXTRACTOR_SYSTEM_PROMPT
+    append_prompt_template = APPEND_EXTRACTOR_PROMPT_TEMPLATE
+    overlap_factor = 3
+
+    def __init__(
+        self,
+        elements: dict,
+        model: BaseChatModel,
+        content: str,
+        chunk_size: int,
+        token_counter: Callable[[str], int],
+    ):
+        self.elements = elements
+        self.model = model
+        self.content = content
+        # self.token_counter = token_counter
+        self.chunk_size = chunk_size
+        self.text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_size // self.overlap_factor,
+            length_function=token_counter,
+        )
+        self.chunks_data = None
+
+    async def extract(
+        self, markdown: str, previous_data: list[dict] | None = None
+    ) -> list[dict]:
+        elements = json.dumps(self.elements)
+        if not previous_data:
+            human_msg = self.prompt_template.format(
+                markdown=markdown, elements=elements
+            )
+        else:
+            cutoff = math.ceil(len(previous_data) / self.overlap_factor)
+            previous_tail = json.dumps(previous_data[cutoff:])
+            human_msg = self.append_prompt_template.format(
+                markdown=markdown, elements=elements, previous_data=previous_tail
+            )
+        messages = [
+            SystemMessage(self.system_prompt),
+            HumanMessage(human_msg),
+        ]
+        output = await self.model.ainvoke(messages)
+        parser = JsonOutputParser()
+        output_dict = parser.parse(output.content)
+        return output_dict
+
+    async def run(
+        self,
+    ) -> dict:
+        if self.system_prompt is None:
+            raise ValueError("system_prompt is not defined for this extractor")
+        if self.prompt_template is None:
+            raise ValueError("prompt_template is not defined for this extractor")
+
+        markdown = markdownify(self.content)
+        # chunks = chunk(
+        #     text=markdown,
+        #     chunk_size=self.chunk_size,
+        #     token_counter=self.token_counter,
+        #     memoize=False,
+        # )
+        chunks = self.text_splitter.create_documents([markdown])
+        if len(chunks) > 1:
+            self.chunks_data = []
+            chunk_data = None
+            for i, element in enumerate(chunks):
+                chunk_data = await self.extract(
+                    markdown=element, previous_data=chunk_data
+                )
+                self.chunks_data.append(chunk_data)
+
+            output_dict = await self.merge_all_data(self.chunks_data)
+        else:
+            output_dict = await self.extract(markdown=chunks[0])
+
+        return output_dict

--- a/parsera/engine/chunks_extractor.py
+++ b/parsera/engine/chunks_extractor.py
@@ -66,10 +66,10 @@ If no data is found return empty json:
 
 SYSTEM_MERGE_PROMPT_TEMPLATE = """
 Your goal is to merge data extracted from different parts of the page into one json.
-Keep the original structure, but make sure to correctly merge data to not have duplicates.
+Keep the original structure, but make sure to correctly merge data to not have duplicates, prefer rows with more data.
 
 In case of conflicting values, take the data that is further from the boarder between the files.
-For example if merging the following jsons:
+## Example: merging conflicting values
 ```
 [
     {"name": "zero element", "price": "123"},
@@ -91,12 +91,47 @@ and
 In the case above the "second element"'s price should be taken from the first json, cause it's further from the boarder
 between the files, while "third element"'s price should be taken from the second json. The final output should be:
 
+Merged json:
 ```
 [
     {"name": "zero element", "price": "123"},
     {"name": "first element", "price": "100"},
     {"name": "second element", "price": "200"},
     {"name": "third element", "price": "400"},
+]
+```
+
+## Example: merging missing values
+```
+[
+    {"name": "zero element", "price": "123"},
+    {"name": "first element", "price": "100"},
+    {"name": "second element", "price": "200"},
+    {"name": "third", "price": null},
+]
+```
+
+and 
+
+```
+[
+    {"name": "second element", "price": "123"},
+    {"name": "third element", "price": "400"},
+    {"name": "fourth element", "price": "350"},
+]
+```
+
+In this case the "third element" should be taken from the second json, because it contains missing value for the "price"
+and fixed truncated name "third". The final output should be:
+
+Merged json:
+```
+[
+    {"name": "zero element", "price": "123"},
+    {"name": "first element", "price": "100"},
+    {"name": "second element", "price": "200"},
+    {"name": "third element", "price": "400"},
+    {"name": "fourth element", "price": "350"},
 ]
 ```
 
@@ -117,11 +152,11 @@ Merged json:
 APPEND_TABULAR_EXTRACTOR_SYSTEM_PROMPT = """
 Your goal is to continue the sequence extracted from the previous chunk of the page by adding elements from the new page
 chunk. Note, that chunks are overlapping, so the data extracted from the previous chunk can appear in the content again,
-in this case always prefer the data from the truncated page chunk. 
+in this case always try to find values for the rows based on the content of the truncated page chunk provided by user. 
 Output json should contain all records you observe on the page.
 
 ## Example: continue truncated json
-Fix and continue this sequence:
+Fill missing values, fix truncated values and continue this sequence:
 ```json
 [
     {"name": "zero product", "price": "25"},
@@ -140,7 +175,7 @@ Return the following elements from the truncated page chunk:
 
 Make sure to fill mussing and truncated values in the previous sequence, while using `null` in the records where data
 was not found. Like in example below, where price for the "fourth product" was not found.
-Output json:
+Output json with fixed previous sequence and new rows:
 ```json
 [
     {"name": "zero product", "price": "25"},
@@ -160,7 +195,7 @@ User requesting the following elements from the truncated page chunk:
 }
 ```
 Make sure to return json with only this field
-Output json:
+Output json with fixed previous sequence and new rows:
 ```json
 [
     {"link": "https://example.com/link1"},
@@ -179,7 +214,7 @@ If no data is found return empty json:
 """
 
 APPEND_EXTRACTOR_PROMPT_TEMPLATE = """
-Fix and continue this sequence:
+Fill missing values, fix truncated values and continue this sequence:
 ```
 {previous_data}
 ```
@@ -194,7 +229,7 @@ You are looking for the following elements from the truncated page chunk:
 {elements}
 ```
 
-Output json with all elements from the previous sequence where new data was found:
+Output json with fixed previous sequence and new rows:
 """
 
 

--- a/parsera/engine/simple_extractor.py
+++ b/parsera/engine/simple_extractor.py
@@ -24,7 +24,9 @@ class Extractor:
     system_prompt = None
     prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
 
-    def __init__(self, elements: dict, model: BaseChatModel, content: str):
+    def __init__(
+        self, elements: dict, model: BaseChatModel, content: str, *args, **kwargs
+    ):
         self.elements = elements
         self.model = model
         self.content = content

--- a/parsera/engine/simple_extractor.py
+++ b/parsera/engine/simple_extractor.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -22,15 +21,15 @@ Output json:
 
 
 class Extractor:
-    system_prompt: Optional[str] = None
-    prompt_template: Optional[str] = None
+    system_prompt = None
+    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
 
     def __init__(self, elements: dict, model: BaseChatModel, content: str):
         self.elements = elements
         self.model = model
         self.content = content
 
-    async def run(self) -> dict:
+    async def run(self) -> list[dict]:
         if self.system_prompt is None:
             raise ValueError("system_prompt is not defined for this extractor")
         if self.prompt_template is None:
@@ -87,12 +86,25 @@ Output json:
 ]
 ```
 
+If value for the field is not found use `null` in the json:
+```json
+[
+    {"name": "name1", "price": "100"},
+    {"name": "name2", "price": null},
+    {"name": "name3", "price": "300"},
+]
+```
+
+If no data is found return empty json:
+```json
+[]
+```
+
 """
 
 
 class TabularExtractor(Extractor):
     system_prompt = TABULAR_EXTRACTOR_SYSTEM_PROMPT
-    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
 
 
 LIST_EXTRACTOR_SYSTEM_PROMPT = """
@@ -129,12 +141,16 @@ Output json:
 }
 ```
 
+If no data is found return empty json:
+```json
+[]
+```
+
 """
 
 
 class ListExtractor(Extractor):
     system_prompt = LIST_EXTRACTOR_SYSTEM_PROMPT
-    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE
 
 
 ITEM_EXTRACTOR_SYSTEM_PROMPT = """
@@ -171,9 +187,13 @@ Output json:
 }
 ```
 
+If no data is found return empty json:
+```json
+[]
+```
+
 """
 
 
 class ItemExtractor(Extractor):
     system_prompt = ITEM_EXTRACTOR_SYSTEM_PROMPT
-    prompt_template = SIMPLE_EXTRACTOR_PROMPT_TEMPLATE

--- a/parsera/parsera.py
+++ b/parsera/parsera.py
@@ -2,9 +2,11 @@ import asyncio
 import enum
 from typing import Awaitable, Callable
 
+import tiktoken
 from langchain_core.language_models import BaseChatModel
 from playwright.async_api import Page
 
+from parsera.engine.chunks_extractor import ChunksTabularExtractor
 from parsera.engine.model import GPT4oMiniModel
 from parsera.engine.simple_extractor import (
     ItemExtractor,
@@ -18,6 +20,7 @@ class ExtractorType(enum.Enum):
     LIST = ListExtractor
     TABULAR = TabularExtractor
     ITEM = ItemExtractor
+    CHUNKS_TABULAR = ChunksTabularExtractor
 
 
 class Parsera:
@@ -25,13 +28,41 @@ class Parsera:
         self,
         model: BaseChatModel | None = None,
         extractor: ExtractorType = ExtractorType.TABULAR,
+        chunk_size: int = 120000,
+        token_counter: Callable[[str], int] | None = None,
     ):
+        """Initialize Parsera
+
+        Args:
+            model (BaseChatModel | None, optional): LangChain Chat Model. Defaults to None which invokes usage of
+                GPT4oMiniModel.
+            extractor (ExtractorType, optional): Extractor type from the ExtractorType enum. Defaults to ExtractorType.TABULAR.
+            chunk_size (int, optional): Number of tokens per chunk, should be below context size of the model used. Defaults to 120000.
+            token_counter (Callable[[str], int] | None, optional): Function used to estimate number of tokens in chunks.
+                If None will use OpenAI tokenizer for gpt-4o model. Defaults to None.
+        """
         if model is None:
             self.model = GPT4oMiniModel()
         else:
             self.model = model
+        if token_counter is None:
+
+            def count_tokens(text):
+                # Initialize the tokenizer for GPT-4o-mini
+                encoding = tiktoken.get_encoding("o200k_base")
+
+                # Count tokens
+                tokens = encoding.encode(text)
+                return len(tokens)
+
+            self._token_counter = count_tokens
+        else:
+            self._token_counter = token_counter
         self.extractor = extractor
+        self.chunk_size = chunk_size
+
         self.loader = PageLoader()
+        self.extractor_instance = None
 
     async def _run(
         self,
@@ -43,10 +74,14 @@ class Parsera:
         content = await self.loader.load_content(
             url=url, proxy_settings=proxy_settings, scrolls_limit=scrolls_limit
         )
-        extractor_instance = self.extractor.value(
-            elements=elements, model=self.model, content=content
+        self.extractor_instance = self.extractor.value(
+            elements=elements,
+            model=self.model,
+            content=content,
+            chunk_size=self.chunk_size,
+            token_counter=self._token_counter,
         )
-        result = await extractor_instance.run()
+        result = await self.extractor_instance.run()
         return result
 
     def run(
@@ -85,10 +120,17 @@ class ParseraScript(Parsera):
         self,
         model: BaseChatModel | None = None,
         extractor: ExtractorType = ExtractorType.TABULAR,
+        chunk_size: int = 120000,
+        token_counter: Callable[[str], int] | None = None,
         initial_script: Callable[[Page], Awaitable[Page]] | None = None,
         stealth: bool = True,
     ):
-        super().__init__(model=model, extractor=extractor)
+        super().__init__(
+            model=model,
+            extractor=extractor,
+            chunk_size=chunk_size,
+            token_counter=token_counter,
+        )
         self.initial_script = initial_script
         self.stealth = stealth
 
@@ -115,18 +157,22 @@ class ParseraScript(Parsera):
             url=url, scrolls_limit=scrolls_limit, playwright_script=playwright_script
         )
 
-        extractor_instance = self.extractor.value(
-            elements=elements, model=self.model, content=content
+        self.extractor_instance = self.extractor.value(
+            elements=elements,
+            model=self.model,
+            content=content,
+            chunk_size=self.chunk_size,
+            token_counter=self._token_counter,
         )
-        result = await extractor_instance.run()
+        result = await self.extractor_instance.run()
         return result
 
     async def _run(
         self,
         url: str,
         elements: dict,
-        scrolls_limit: int = 0,
         proxy_settings: dict | None = None,
+        scrolls_limit: int = 0,
         playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
     ):
         if self.loader.context is None:
@@ -146,8 +192,8 @@ class ParseraScript(Parsera):
         self,
         url: str,
         elements: dict,
-        scrolls_limit: int = 0,
         proxy_settings: dict | None = None,
+        scrolls_limit: int = 0,
         playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
     ) -> dict:
         return asyncio.run(
@@ -164,8 +210,8 @@ class ParseraScript(Parsera):
         self,
         url: str,
         elements: dict,
-        scrolls_limit: int = 0,
         proxy_settings: dict | None = None,
+        scrolls_limit: int = 0,
         playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
     ) -> dict:
         return await self._run(

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,8 +283,8 @@ files = [
 lazy-object-proxy = ">=1.4.0"
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
-    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
+    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
 ]
 
 [[package]]
@@ -1680,8 +1680,8 @@ langchain-core = ">=0.2.38,<0.3.0"
 langchain-text-splitters = ">=0.2.0,<0.3.0"
 langsmith = ">=0.1.17,<0.2.0"
 numpy = [
-    {version = ">=1.26.0,<2.0.0", markers = "python_version >= \"3.12\""},
     {version = ">=1,<2", markers = "python_version < \"3.12\""},
+    {version = ">=1.26.0,<2.0.0", markers = "python_version >= \"3.12\""},
 ]
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
@@ -1705,8 +1705,8 @@ jsonpatch = ">=1.33,<2.0"
 langsmith = ">=0.1.112,<0.2.0"
 packaging = ">=23.2,<25"
 pydantic = [
-    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
     {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""},
+    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
 ]
 PyYAML = ">=5.3"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<9.0.0"
@@ -1757,8 +1757,8 @@ files = [
 httpx = ">=0.23.0,<1"
 orjson = ">=3.9.14,<4.0.0"
 pydantic = [
-    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
     {version = ">=1,<3", markers = "python_full_version < \"3.12.4\""},
+    {version = ">=2.7.4,<3.0.0", markers = "python_full_version >= \"3.12.4\""},
 ]
 requests = ">=2,<3"
 
@@ -2949,8 +2949,8 @@ files = [
 annotated-types = ">=0.6.0"
 pydantic-core = "2.23.4"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 
 [package.extras]
@@ -3115,8 +3115,8 @@ files = [
 astroid = ">=2.15.8,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
     {version = ">=0.2", markers = "python_version < \"3.11\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
 ]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
@@ -4080,47 +4080,42 @@ typing = ["mypy (>=1.6,<2.0)", "traitlets (>=5.11.1)"]
 
 [[package]]
 name = "tiktoken"
-version = "0.7.0"
+version = "0.8.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "tiktoken-0.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485f3cc6aba7c6b6ce388ba634fbba656d9ee27f766216f45146beb4ac18b25f"},
-    {file = "tiktoken-0.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e54be9a2cd2f6d6ffa3517b064983fb695c9a9d8aa7d574d1ef3c3f931a99225"},
-    {file = "tiktoken-0.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79383a6e2c654c6040e5f8506f3750db9ddd71b550c724e673203b4f6b4b4590"},
-    {file = "tiktoken-0.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d4511c52caacf3c4981d1ae2df85908bd31853f33d30b345c8b6830763f769c"},
-    {file = "tiktoken-0.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13c94efacdd3de9aff824a788353aa5749c0faee1fbe3816df365ea450b82311"},
-    {file = "tiktoken-0.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8e58c7eb29d2ab35a7a8929cbeea60216a4ccdf42efa8974d8e176d50c9a3df5"},
-    {file = "tiktoken-0.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:21a20c3bd1dd3e55b91c1331bf25f4af522c525e771691adbc9a69336fa7f702"},
-    {file = "tiktoken-0.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:10c7674f81e6e350fcbed7c09a65bca9356eaab27fb2dac65a1e440f2bcfe30f"},
-    {file = "tiktoken-0.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:084cec29713bc9d4189a937f8a35dbdfa785bd1235a34c1124fe2323821ee93f"},
-    {file = "tiktoken-0.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:811229fde1652fedcca7c6dfe76724d0908775b353556d8a71ed74d866f73f7b"},
-    {file = "tiktoken-0.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86b6e7dc2e7ad1b3757e8a24597415bafcfb454cebf9a33a01f2e6ba2e663992"},
-    {file = "tiktoken-0.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1063c5748be36344c7e18c7913c53e2cca116764c2080177e57d62c7ad4576d1"},
-    {file = "tiktoken-0.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20295d21419bfcca092644f7e2f2138ff947a6eb8cfc732c09cc7d76988d4a89"},
-    {file = "tiktoken-0.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:959d993749b083acc57a317cbc643fb85c014d055b2119b739487288f4e5d1cb"},
-    {file = "tiktoken-0.7.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:71c55d066388c55a9c00f61d2c456a6086673ab7dec22dd739c23f77195b1908"},
-    {file = "tiktoken-0.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:09ed925bccaa8043e34c519fbb2f99110bd07c6fd67714793c21ac298e449410"},
-    {file = "tiktoken-0.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03c6c40ff1db0f48a7b4d2dafeae73a5607aacb472fa11f125e7baf9dce73704"},
-    {file = "tiktoken-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d20b5c6af30e621b4aca094ee61777a44118f52d886dbe4f02b70dfe05c15350"},
-    {file = "tiktoken-0.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d427614c3e074004efa2f2411e16c826f9df427d3c70a54725cae860f09e4bf4"},
-    {file = "tiktoken-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8c46d7af7b8c6987fac9b9f61041b452afe92eb087d29c9ce54951280f899a97"},
-    {file = "tiktoken-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:0bc603c30b9e371e7c4c7935aba02af5994a909fc3c0fe66e7004070858d3f8f"},
-    {file = "tiktoken-0.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2398fecd38c921bcd68418675a6d155fad5f5e14c2e92fcf5fe566fa5485a858"},
-    {file = "tiktoken-0.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f5f6afb52fb8a7ea1c811e435e4188f2bef81b5e0f7a8635cc79b0eef0193d6"},
-    {file = "tiktoken-0.7.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:861f9ee616766d736be4147abac500732b505bf7013cfaf019b85892637f235e"},
-    {file = "tiktoken-0.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54031f95c6939f6b78122c0aa03a93273a96365103793a22e1793ee86da31685"},
-    {file = "tiktoken-0.7.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:fffdcb319b614cf14f04d02a52e26b1d1ae14a570f90e9b55461a72672f7b13d"},
-    {file = "tiktoken-0.7.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:c72baaeaefa03ff9ba9688624143c858d1f6b755bb85d456d59e529e17234769"},
-    {file = "tiktoken-0.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:131b8aeb043a8f112aad9f46011dced25d62629091e51d9dc1adbf4a1cc6aa98"},
-    {file = "tiktoken-0.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cabc6dc77460df44ec5b879e68692c63551ae4fae7460dd4ff17181df75f1db7"},
-    {file = "tiktoken-0.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8d57f29171255f74c0aeacd0651e29aa47dff6f070cb9f35ebc14c82278f3b25"},
-    {file = "tiktoken-0.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ee92776fdbb3efa02a83f968c19d4997a55c8e9ce7be821ceee04a1d1ee149c"},
-    {file = "tiktoken-0.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e215292e99cb41fbc96988ef62ea63bb0ce1e15f2c147a61acc319f8b4cbe5bf"},
-    {file = "tiktoken-0.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8a81bac94769cab437dd3ab0b8a4bc4e0f9cf6835bcaa88de71f39af1791727a"},
-    {file = "tiktoken-0.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d6d73ea93e91d5ca771256dfc9d1d29f5a554b83821a1dc0891987636e0ae226"},
-    {file = "tiktoken-0.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:2bcb28ddf79ffa424f171dfeef9a4daff61a94c631ca6813f43967cb263b83b9"},
-    {file = "tiktoken-0.7.0.tar.gz", hash = "sha256:1077266e949c24e0291f6c350433c6f0971365ece2b173a23bc3b9f9defef6b6"},
+    {file = "tiktoken-0.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b07e33283463089c81ef1467180e3e00ab00d46c2c4bbcef0acab5f771d6695e"},
+    {file = "tiktoken-0.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9269348cb650726f44dd3bbb3f9110ac19a8dcc8f54949ad3ef652ca22a38e21"},
+    {file = "tiktoken-0.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e13f37bc4ef2d012731e93e0fef21dc3b7aea5bb9009618de9a4026844e560"},
+    {file = "tiktoken-0.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f13d13c981511331eac0d01a59b5df7c0d4060a8be1e378672822213da51e0a2"},
+    {file = "tiktoken-0.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6b2ddbc79a22621ce8b1166afa9f9a888a664a579350dc7c09346a3b5de837d9"},
+    {file = "tiktoken-0.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d8c2d0e5ba6453a290b86cd65fc51fedf247e1ba170191715b049dac1f628005"},
+    {file = "tiktoken-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d622d8011e6d6f239297efa42a2657043aaed06c4f68833550cac9e9bc723ef1"},
+    {file = "tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2efaf6199717b4485031b4d6edb94075e4d79177a172f38dd934d911b588d54a"},
+    {file = "tiktoken-0.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5637e425ce1fc49cf716d88df3092048359a4b3bbb7da762840426e937ada06d"},
+    {file = "tiktoken-0.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb0e352d1dbe15aba082883058b3cce9e48d33101bdaac1eccf66424feb5b47"},
+    {file = "tiktoken-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:56edfefe896c8f10aba372ab5706b9e3558e78db39dd497c940b47bf228bc419"},
+    {file = "tiktoken-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:326624128590def898775b722ccc327e90b073714227175ea8febbc920ac0a99"},
+    {file = "tiktoken-0.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:881839cfeae051b3628d9823b2e56b5cc93a9e2efb435f4cf15f17dc45f21586"},
+    {file = "tiktoken-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fe9399bdc3f29d428f16a2f86c3c8ec20be3eac5f53693ce4980371c3245729b"},
+    {file = "tiktoken-0.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a58deb7075d5b69237a3ff4bb51a726670419db6ea62bdcd8bd80c78497d7ab"},
+    {file = "tiktoken-0.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2908c0d043a7d03ebd80347266b0e58440bdef5564f84f4d29fb235b5df3b04"},
+    {file = "tiktoken-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:294440d21a2a51e12d4238e68a5972095534fe9878be57d905c476017bff99fc"},
+    {file = "tiktoken-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:d8f3192733ac4d77977432947d563d7e1b310b96497acd3c196c9bddb36ed9db"},
+    {file = "tiktoken-0.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:02be1666096aff7da6cbd7cdaa8e7917bfed3467cd64b38b1f112e96d3b06a24"},
+    {file = "tiktoken-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94ff53c5c74b535b2cbf431d907fc13c678bbd009ee633a2aca269a04389f9a"},
+    {file = "tiktoken-0.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b231f5e8982c245ee3065cd84a4712d64692348bc609d84467c57b4b72dcbc5"},
+    {file = "tiktoken-0.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4177faa809bd55f699e88c96d9bb4635d22e3f59d635ba6fd9ffedf7150b9953"},
+    {file = "tiktoken-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5376b6f8dc4753cd81ead935c5f518fa0fbe7e133d9e25f648d8c4dabdd4bad7"},
+    {file = "tiktoken-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:18228d624807d66c87acd8f25fc135665617cab220671eb65b50f5d70fa51f69"},
+    {file = "tiktoken-0.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7e17807445f0cf1f25771c9d86496bd8b5c376f7419912519699f3cc4dc5c12e"},
+    {file = "tiktoken-0.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:886f80bd339578bbdba6ed6d0567a0d5c6cfe198d9e587ba6c447654c65b8edc"},
+    {file = "tiktoken-0.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6adc8323016d7758d6de7313527f755b0fc6c72985b7d9291be5d96d73ecd1e1"},
+    {file = "tiktoken-0.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b591fb2b30d6a72121a80be24ec7a0e9eb51c5500ddc7e4c2496516dd5e3816b"},
+    {file = "tiktoken-0.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:845287b9798e476b4d762c3ebda5102be87ca26e5d2c9854002825d60cdb815d"},
+    {file = "tiktoken-0.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:1473cfe584252dc3fa62adceb5b1c763c1874e04511b197da4e6de51d6ce5a02"},
+    {file = "tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2"},
 ]
 
 [package.dependencies]
@@ -4896,4 +4891,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.0"
-content-hash = "8d6a377250faee60ef5c2cdcc6341242815b5b379c9fb88d456f4ec580c839c7"
+content-hash = "e577d737536ff406d45f1b2ef2b54144d8b5d55f0eee638d0151283ec1ccdcf5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3169,6 +3169,24 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.24.0"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b"},
+    {file = "pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276"},
+]
+
+[package.dependencies]
+pytest = ">=8.2,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -4891,4 +4909,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.0"
-content-hash = "e577d737536ff406d45f1b2ef2b54144d8b5d55f0eee638d0151283ec1ccdcf5"
+content-hash = "d93f831278afe2598bfbcf52e07c03b696d9eaf1ad8abe95441cf02dd51e6701"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ markdownify = "^0.13.1"
 python-dotenv = "^1.0.1"
 argparse = "^1.4.0"
 colorama = "^0.4.6"
+tiktoken = "^0.8.0"
+langchain-text-splitters = "0.2.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pytest = "^8.2.2"
 jupyterlab = "^4.2.4"
 mkdocs = "^1.6.1"
 mkdocs-material = "^9.5.34"
+pytest-asyncio = "^0.24.0"
 
 [tool.poetry.group.transformers]
 optional = true

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,55 @@
+import os
+
+import pytest
+from langchain_openai import AzureChatOpenAI
+
+from parsera import ExtractorType, Parsera
+
+llm = AzureChatOpenAI(
+    azure_endpoint=os.getenv("AZURE_GPT_BASE_URL"),
+    openai_api_version="2023-05-15",
+    deployment_name=os.getenv("AZURE_GPT_DEPLOYMENT_NAME"),
+    openai_api_key=os.getenv("AZURE_GPT_API_KEY"),
+    openai_api_type="azure",
+    temperature=0.0,
+)
+
+
+def values_to_strings(dicts_list: list[dict]):
+    for i in range(len(dicts_list)):
+        for k, v in dicts_list[i].items():
+            dicts_list[i][k] = str(v)
+    return dicts_list
+
+
+async def run_chunks_and_no_chunks(url: str, elements: dict, small_chunk_size: int):
+    scraper_long_chunk = Parsera(
+        model=llm, chunk_size=100000, extractor=ExtractorType.CHUNKS_TABULAR
+    )
+    result_no_chunks = await scraper_long_chunk.arun(
+        url=url, elements=elements, proxy_settings=None
+    )
+
+    scraper_small_chunk = Parsera(
+        model=llm, chunk_size=small_chunk_size, extractor=ExtractorType.CHUNKS_TABULAR
+    )
+    result_chunks = await scraper_small_chunk.arun(
+        url=url, elements=elements, proxy_settings=None
+    )
+    result_no_chunks = values_to_strings(result_no_chunks)
+    result_chunks = values_to_strings(result_chunks)
+    return result_no_chunks, result_chunks
+
+
+@pytest.mark.asyncio
+async def test_chunking_hackernews():
+    url = "https://news.ycombinator.com/front?day=2024-09-05"
+    elements = {
+        "Title": "News title",
+        "Points": "Number of points (only number)",
+        "Comments": "Number of comments (only number)",
+    }
+    result_no_chunks, result_chunks = await run_chunks_and_no_chunks(
+        url, elements, small_chunk_size=1500
+    )
+    assert result_no_chunks == result_chunks

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -53,3 +53,18 @@ async def test_chunking_hackernews():
         url, elements, small_chunk_size=1500
     )
     assert result_no_chunks == result_chunks
+
+
+@pytest.mark.asyncio
+async def test_chunking_egen_ai():
+    url = "https://egen.ai/people/careers/"
+    elements = {
+        "Title": "Title of job",
+        "Location": "Location of job",
+        "Type": "If the job is Remote or Not-Remote",
+        "Link": "Link to the post",
+    }
+    result_no_chunks, result_chunks = await run_chunks_and_no_chunks(
+        url, elements, small_chunk_size=1500
+    )
+    assert result_no_chunks != result_chunks


### PR DESCRIPTION
Chunks extractor allows processing pages that are over context limit by providing the `chunk_size` parameter for input chunking and a `token_counter` function for counting a number of tokens during chunks creation (by default OpenAI's `o200k_base` tokenizer is used). For example, if I am using OpenAI models with 16k context size, I can turn on processing page in 10k tokens chunks:
```python
import tiktoken

from parsera import Parsera, ExtractorType

def count_tokens(text):
    # Initialize the tokenizer for GPT-4o-mini
    encoding = tiktoken.get_encoding("o200k_base")

    # Count tokens
    tokens = encoding.encode(text)
    return len(tokens)

scraper = Parsera(
    model=llm,
    chunk_size=10000,
    token_counter=count_tokens,
    extractor=ExtractorType.CHUNKS_TABULAR
)
result_chunk = await scraper.arun(url=url, elements=elements, proxy_settings=None)
```