### PR TITLE
Refactoring Extractors and their usage in Parsera

### DIFF
--- a/docs/features/custom-playwright.md
+++ b/docs/features/custom-playwright.md
@@ -39,7 +39,7 @@ result = await parsera.arun(
 ## Access Playwright instance
 The page is fetched via the `Parsera.loader`, which contains the playwright instance.
 ```python
-from parsera import ParseraScript
+from parsera import Parsera
 
 parsera = Parsera(model=model)
 

--- a/docs/features/extractors.md
+++ b/docs/features/extractors.md
@@ -3,7 +3,7 @@ There are different types of extractors, that provide output in different format
 
 - For tables.
     - `ChunksTabularExtractor` - for tables, capable of processing larger pages with chunking
-    - `TabularExtractor` - for tables
+    - `TabularExtractor` - for tables, without chunking (fails when page doesn't fit into the model's context)
 - `ListExtractor` for separate lists of values.
 - `ItemExtractor` for specific values.
 
@@ -11,9 +11,11 @@ By default a [`ChunksTabularExtractor`](#chunks-tabular-extractor) is used.
 
 ## Tabular Extractor
 ```python
-from parsera import Parsera, ExtractorType
+from parsera import Parsera
+from parsera.engine.simple_extractor import TabularExtractor
 
-scraper = Parsera(extractor=ExtractorType.TABULAR)
+extractor = TabularExtractor()
+scraper = Parsera(extractor=extractor)
 ```
 The tabular extractor is used to find rows of tabular data and has output of the form:
 ```json
@@ -26,11 +28,13 @@ The tabular extractor is used to find rows of tabular data and has output of the
 
 ## Chunks Tabular Extractor
 Provides the same output format as `TabularExtractor`, but capable of processing larger pages due to page chunking.
-For example, if your model has 16k context size, you can set chunks to be not larger than 12k:
+For example, if your model has 16k context size, you can set chunks to be not larger than 12k (keeping 4k buffer for other parts of the prompt):
 ```python
-from parsera import Parsera, ExtractorType
+from parsera import Parsera
+from parsera.engine.chunks_extractor import ChunksTabularExtractor
 
-scraper = Parsera(extractor=ExtractorType.CHUNKS_TABULAR, chunk_size=12000)
+extractor = ChunksTabularExtractor(chunk_size=12000)
+scraper = Parsera(extractor=extractor)
 ```
 
 By default number of tokens is counted based on the OpenAI tokenizer for `gpt-4o` model, but you can provide custom
@@ -53,9 +57,11 @@ scraper = Parsera(extractor=ExtractorType.CHUNKS_TABULAR, chunk_size=12000, toke
 
 ## List Extractor
 ```python
-from parsera import Parsera, ExtractorType
+from parsera import Parsera
+from parsera.engine.simple_extractor import ListExtractor
 
-scraper = Parsera(extractor=ExtractorType.LIST)
+extractor = ListExtractor()
+scraper = Parsera(extractor=extractor)
 ```
 The list extractor is used to find lists of different values and has output of the form:
 ```json
@@ -67,9 +73,11 @@ The list extractor is used to find lists of different values and has output of t
 
 ## Item Extractor
 ```python
-from parsera import Parsera, ExtractorType
+from parsera import Parsera
+from parsera.engine.simple_extractor import ItemExtractor
 
-scraper = Parsera(extractor=ExtractorType.ITEM)
+extractor = ItemExtractor()
+scraper = Parsera(extractor=extractor)
 ```
 The item extractor is used to get singular items from a page like a title or price and has output of the form:
 ```json

--- a/docs/features/proxy.md
+++ b/docs/features/proxy.md
@@ -1,12 +1,15 @@
 ## Using proxy
 You can use serve the traffic via proxy server when calling `run` method:
 ```python
+from parsera import Parsera
+
+scraper = Parsera()
 proxy_settings = {
     "server": "https://1.2.3.4:5678",
     "username": <PROXY_USERNAME>,
     "password": <PROXY_PASSWORD>,
 }
-result = scrapper.run(url=url, elements=elements, proxy_settings=proxy_settings)
+result = scraper.run(url=url, elements=elements, proxy_settings=proxy_settings)
 ```
 
 Where `proxy_settings` contains your proxy credentials.

--- a/parsera/__init__.py
+++ b/parsera/__init__.py
@@ -1,3 +1,3 @@
-from parsera.parsera import ExtractorType, Parsera
+from parsera.parsera import Parsera
 
-__all__ = ["ExtractorType", "Parsera"]
+__all__ = ["Parsera"]

--- a/parsera/engine/simple_extractor.py
+++ b/parsera/engine/simple_extractor.py
@@ -26,27 +26,23 @@ class Extractor:
 
     def __init__(
         self,
-        elements: dict,
         model: BaseChatModel,
-        content: str,
         converter: MarkdownConverter | None = None,
     ):
-        self.elements = elements
         self.model = model
-        self.content = content
         if converter is None:
             self.converter = MarkdownConverter()
         else:
             self.converter = converter
 
-    async def run(self) -> list[dict]:
+    async def run(self, content: str, attributes: dict[str, str]) -> list[dict]:
         if self.system_prompt is None:
             raise ValueError("system_prompt is not defined for this extractor")
         if self.prompt_template is None:
             raise ValueError("prompt_template is not defined for this extractor")
 
-        markdown = self.converter.convert(self.content)
-        elements = json.dumps(self.elements)
+        markdown = self.converter.convert(content)
+        elements = json.dumps(attributes)
         human_msg = self.prompt_template.format(markdown=markdown, elements=elements)
         messages = [
             SystemMessage(self.system_prompt),

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -3,7 +3,8 @@ import os
 import pytest
 from langchain_openai import AzureChatOpenAI
 
-from parsera import ExtractorType, Parsera
+from parsera import Parsera
+from parsera.engine.chunks_extractor import ChunksTabularExtractor
 
 llm = AzureChatOpenAI(
     azure_endpoint=os.getenv("AZURE_GPT_BASE_URL"),
@@ -23,16 +24,16 @@ def values_to_strings(dicts_list: list[dict]):
 
 
 async def run_chunks_and_no_chunks(url: str, elements: dict, small_chunk_size: int):
-    scraper_long_chunk = Parsera(
-        model=llm, chunk_size=100000, extractor=ExtractorType.CHUNKS_TABULAR
-    )
+    extractor = ChunksTabularExtractor(model=llm, chunk_size=100000)
+    scraper_long_chunk = Parsera(model=llm, extractor=extractor)
     result_no_chunks = await scraper_long_chunk.arun(
         url=url, elements=elements, proxy_settings=None
     )
 
-    scraper_small_chunk = Parsera(
-        model=llm, chunk_size=small_chunk_size, extractor=ExtractorType.CHUNKS_TABULAR
+    extractor_small_chunk = ChunksTabularExtractor(
+        model=llm, chunk_size=small_chunk_size
     )
+    scraper_small_chunk = Parsera(model=llm, extractor=extractor_small_chunk)
     result_chunks = await scraper_small_chunk.arun(
         url=url, elements=elements, proxy_settings=None
     )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,30 @@
+import os
+
+import pytest
+from langchain_openai import AzureChatOpenAI
+
+from parsera import Parsera
+
+llm = AzureChatOpenAI(
+    azure_endpoint=os.getenv("AZURE_GPT_BASE_URL"),
+    openai_api_version="2023-05-15",
+    deployment_name=os.getenv("AZURE_GPT_DEPLOYMENT_NAME"),
+    openai_api_key=os.getenv("AZURE_GPT_API_KEY"),
+    openai_api_type="azure",
+    temperature=0.0,
+)
+
+
+@pytest.mark.asyncio
+async def test_smoke():
+    url = "https://news.ycombinator.com/"
+    elements = {
+        "Title": "News title",
+        "Points": "Number of points",
+        "Comments": "Number of comments",
+    }
+
+    scraper = Parsera(model=llm)
+    result = await scraper.arun(url=url, elements=elements, proxy_settings=None)
+
+    assert result


### PR DESCRIPTION
- moving `content` and `elements` into the `run` method of extractors.
- replacing `ExtractorTyep` enum with dependency injection in `Parsera`